### PR TITLE
google chrome div item didn't drag 

### DIFF
--- a/src/directives/draggable.js
+++ b/src/directives/draggable.js
@@ -66,11 +66,11 @@ dragdropModule.directive('draggable', [
           $element.css('position', 'relative');
         }
         
-        if (top === '') {
+        if (top === ''  || top === 'auto') {
           $element.css('top', '0px');
         }
         
-        if (left === '') {
+        if (left === '' || left === 'auto') {
           $element.css('left', '0px');
         }
       })();


### PR DESCRIPTION
top and left were getting set as auto on chrome browser, even though it worked fine on the firefox.
Adding below checks worked fine on firefox.
